### PR TITLE
init example

### DIFF
--- a/models/pytorch_vision.md
+++ b/models/pytorch_vision.md
@@ -1,0 +1,50 @@
+# Github Link
+github.com/pytorch/vision
+
+# Models
+<!--- List your models here --->
+
+## Model name
+resnet18
+
+### Short Description:
+Resnet-18 model in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385)
+
+### Long Description
+bla
+bla
+bla
+
+### Tags
+CV, resnet
+
+### Code Snippet
+```
+import torch
+model = torch.hub.load('pytorch/vision', 'resnet18', pretrained=True)
+```
+
+### Images(optional)
+
+## Model name
+resnet50
+
+### Short Description
+Resnet-50 model in [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385)
+
+### Long Description
+bla
+bla
+bla
+
+### Code Snippet
+```
+import torch
+model = torch.hub.load('pytorch/vision', 'resnet50', pretrained=True)
+```
+
+### Tags
+CV, resnet
+
+### Images(optional)
+


### PR DESCRIPTION
So the idea here should be one model -> one model card on webpage. But to keep the repo clean, we probably only want one md file (with name `repo_owner/repo_name.md`) per github repo, containing all models published in the repo.  Github link should be shared among all model cards. 

According to the quip we have separate "Description" for card view and full description for sub page. I separate them in "Short Description" and "Long Description" sections. Maybe we could unify them? 

For images section, I'm not sure how webpage could fetch the image from a markdown? 

