### PR TITLE
Add order property to markdown files

### DIFF
--- a/facebookresearch_pytorch-gan-zoo_dcgan.md
+++ b/facebookresearch_pytorch-gan-zoo_dcgan.md
@@ -11,6 +11,7 @@ tags: [vision, generative]
 github-link: https://github.com/facebookresearch/pytorch_GAN_zoo/blob/master/models/DCGAN.py
 featured_image_1: dcgan_fashionGen.jpg
 featured_image_2: no-image
+order: 10
 ---
 
 ```python

--- a/facebookresearch_pytorch-gan-zoo_pgan.md
+++ b/facebookresearch_pytorch-gan-zoo_pgan.md
@@ -11,6 +11,7 @@ tags: [vision, generative]
 github-link: https://github.com/facebookresearch/pytorch_GAN_zoo/blob/master/models/progressive_gan.py
 featured_image_1: pgan_mix.jpg
 featured_image_2: pgan_celebaHQ.jpg
+order: 3
 ---
 
 

--- a/huggingface_pytorch-pretrained-bert_bert.md
+++ b/huggingface_pytorch-pretrained-bert_bert.md
@@ -11,6 +11,7 @@ tags: [nlp]
 github-link: https://github.com/huggingface/pytorch-pretrained-BERT.git
 featured_image_1: bert1.png
 featured_image_2: bert2.png
+order: 2
 ---
 
 ### Model Description

--- a/huggingface_pytorch-pretrained-bert_gpt.md
+++ b/huggingface_pytorch-pretrained-bert_gpt.md
@@ -11,6 +11,7 @@ tags: [nlp]
 github-link: https://github.com/huggingface/pytorch-pretrained-BERT.git
 featured_image_1: GPT1.png
 featured_image_2: no-image
+order: 10
 ---
 
 ### Model Description

--- a/pytorch_vision_alexnet.md
+++ b/pytorch_vision_alexnet.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/alexnet.py
 featured_image_1: alexnet1.png
 featured_image_2: alexnet2.png
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_deeplabv3_resnet101.md
+++ b/pytorch_vision_deeplabv3_resnet101.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/segmentation/deeplabv3.py
 featured_image_1: deeplab1.png
 featured_image_2: deeplab2.png
+order: 1
 ---
 
 ```python

--- a/pytorch_vision_densenet.md
+++ b/pytorch_vision_densenet.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py
 featured_image_1: densenet1.png
 featured_image_2: densenet2.png
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_fcn_resnet101.md
+++ b/pytorch_vision_fcn_resnet101.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/segmentation/fcn.py
 featured_image_1: deeplab1.png
 featured_image_2: fcn2.png
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_googlenet.md
+++ b/pytorch_vision_googlenet.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/googlenet.py
 featured_image_1: googlenet1.png
 featured_image_2: googlenet2.png
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_inception_v3.md
+++ b/pytorch_vision_inception_v3.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/inception.py
 featured_image_1: inception_v3.png
 featured_image_2: no-image
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_mobilenet_v2.md
+++ b/pytorch_vision_mobilenet_v2.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/mobilenet.py
 featured_image_1: mobilenet_v2_1.png
 featured_image_2: mobilenet_v2_2.png
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_resnet.md
+++ b/pytorch_vision_resnet.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 featured_image_1: resnet.png
 featured_image_2: no-image
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_resnext.md
+++ b/pytorch_vision_resnext.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 featured_image_1: resnext.png
 featured_image_2: no-image
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_shufflenet_v2.md
+++ b/pytorch_vision_shufflenet_v2.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/shufflenetv2.py
 featured_image_1: shufflenet_v2_1.png
 featured_image_2: shufflenet_v2_2.png
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_squeezenet.md
+++ b/pytorch_vision_squeezenet.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/squeezenet.py
 featured_image_1: squeezenet.png
 featured_image_2: no-image
+order: 10
 ---
 
 ```python

--- a/pytorch_vision_vgg.md
+++ b/pytorch_vision_vgg.md
@@ -11,6 +11,7 @@ tags: [vision]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/vgg.py
 featured_image_1: vgg.png
 featured_image_2: no-image
+order: 10
 ---
 
 ```python


### PR DESCRIPTION
This PR adds an order property to each markdown file. This property will allow you to configure which model cards show up in the top 3 visible slots on PyTorch Hub. The top 3 cards have order properties that look like:

- order: 1 
- order: 2 
- order: 3

The rest of the cards have an order of 10. Every hub markdown file will now need the order property added so that it displays properly on the hub page.