### PR TITLE
add more structured validation and parsing in sanity_check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ conda install -y pytorch torchvision -c pytorch
 
 # Dependencies required to load models
 conda install -y regex pillow tqdm boto3 requests numpy\
-    h5py scipy matplotlib unidecode ipython
+    h5py scipy matplotlib unidecode ipython pyyaml
 conda install -y -c conda-forge librosa inflect
 
-pip install -q visdom
+pip install -q visdom mistune


### PR DESCRIPTION
The CI was failing on valid files in https://github.com/pytorch/hub/pull/40 , so I cleaned up the sanity-check.py script to include proper parsers for the yaml and markdown sections and validate them in a more structured way