### PR TITLE
Fix indexing in maskedLM_model predictions

### DIFF
--- a/huggingface_pytorch-pretrained-bert_bert.md
+++ b/huggingface_pytorch-pretrained-bert_bert.md
@@ -107,16 +107,6 @@ with torch.no_grad():
 ```
 
 ```python
-### Classify next sentence using ``bertForNextSentencePrediction``
-nextSent_model = torch.hub.load('huggingface/pytorch-pretrained-BERT', 'bertForNextSentencePrediction', 'bert-base-cased')
-nextSent_model.eval()
-
-# Predict the next sentence classification logits
-with torch.no_grad():
-    next_sent_classif_logits = nextSent_model(tokens_tensor, segments_tensors)
-```
-
-```python
 ### Question answering using `bertForQuestionAnswering`
 questionAnswering_model = torch.hub.load('huggingface/pytorch-pretrained-BERT', 'bertForQuestionAnswering', 'bert-base-cased')
 questionAnswering_model.eval()

--- a/huggingface_pytorch-pretrained-bert_bert.md
+++ b/huggingface_pytorch-pretrained-bert_bert.md
@@ -85,7 +85,7 @@ with torch.no_grad():
     predictions = maskedLM_model(tokens_tensor, segments_tensors)
 
 # Get the predicted token
-predicted_index = torch.argmax(predictions[0, masked_index]).item()
+predicted_index = torch.argmax(predictions[0][0, masked_index]).item()
 predicted_token = tokenizer.convert_ids_to_tokens([predicted_index])[0]
 assert predicted_token == 'Jim'
 ```


### PR DESCRIPTION
Hi Pytorch team,

I was running through the PyTorch Hub BERT example (with GPU runtime on colab) and encountered an error described below:

```
with torch.no_grad():
    predictions = maskedLM_model(tokens_tensor, segments_tensors)

print(predictions)
print(predictions[0].shape)
```
This code snippet creates a tuple containing a Tensor
```
(tensor([[[ -7.3300,  -7.2569,  -7.3678,  ...,  -6.0393,  -5.7662,  -6.1471],
         [ -5.8994,  -5.9707,  -5.8014,  ...,  -5.0724,  -3.3948,  -4.7892],
         [-12.4256, -13.9774, -12.2351,  ...,  -9.4624,  -8.8215,  -8.5660],
         ...,
         [ -6.4254,  -5.6587,  -5.0677,  ...,  -4.9743,  -5.3498,  -5.8719],
         [ -8.1874,  -8.5606,  -8.0970,  ...,  -8.6983,  -8.0946,  -7.8000],
         [-15.4673, -15.6826, -14.9941,  ..., -11.8838, -12.5484, -13.5325]]]),)
torch.Size([1, 16, 28996])
```
So an indexing error occurs on this line
```
# Get the predicted token
predicted_index = torch.argmax(predictions[0, masked_index]).item()
predicted_token = tokenizer.convert_ids_to_tokens([predicted_index])[0]
assert predicted_token == 'Jim'

TypeError                                 Traceback (most recent call last)
<ipython-input-10-2b81ead8cd02> in <module>()
     11 
     12 # Get the predicted token
---> 13 predicted_index = torch.argmax(predictions[0, masked_index]).item()
     14 predicted_token = tokenizer.convert_ids_to_tokens([predicted_index])[0]
     15 assert predicted_token == 'Jim'

TypeError: tuple indices must be integers or slices, not tuple
```
This can be fixed for the sake of the example by adding an additional 0 index in front to access the Tensor
```
 # Get the predicted token
predicted_index = torch.argmax(predictions[0][0, masked_index]).item()
predicted_token = tokenizer.convert_ids_to_tokens([predicted_index])[0]
assert predicted_token == 'Jim'
```

Thanks,
Ryan