### PR TITLE
Switch CI to use nightly build

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,8 +14,8 @@ chmod +x "$filename"
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-# Install the latest release of pytorch and torchvision
-conda install -y pytorch torchvision -c pytorch
+# Install the nightly release of pytorch and torchvision
+conda install -y pytorch torchvision -c pytorch-nightly
 
 # Dependencies required to load models
 conda install -y regex pillow tqdm boto3 requests numpy\


### PR DESCRIPTION
Now that all the torchvision models in pytorch hub are scriptable, I would like to add a tag to  for scriptable models (next to `audio` `generative` `nlp` and `vision`), as well as show inline usage on each model page. 

```
import torch
model = torch.hub.load('pytorch/vision', 'deeplabv3_resnet101', pretrained=True)
scripted_model = torch.jit.script(model)
```

I can't currently do this because the CI runs of off 1.2, and torchvision relies on features that are were added between 1.2 and 1.3 

Do we run off 1.2 because these are intended to be run on the default pytorch installed on colab? 
Another alternative is to build off of the 1.3 branch in anticipation for the 1.3 release. 

This also relates to https://github.com/pytorch/hub/issues/55

