### PR TITLE
add scriptable tag

### DIFF
--- a/pytorch_vision_alexnet.md
+++ b/pytorch_vision_alexnet.md
@@ -7,7 +7,7 @@ summary: The 2012 ImageNet winner achieved a top-5 error of 15.3%, more than 10.
 category: researchers
 image: alexnet2.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/alexnet.py
 featured_image_1: alexnet1.png
 featured_image_2: alexnet2.png

--- a/pytorch_vision_deeplabv3_resnet101.md
+++ b/pytorch_vision_deeplabv3_resnet101.md
@@ -7,7 +7,7 @@ summary: DeepLabV3 model with a ResNet-101 backbone
 category: researchers
 image: deeplab2.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/segmentation/deeplabv3.py
 featured_image_1: deeplab1.png
 featured_image_2: deeplab2.png

--- a/pytorch_vision_densenet.md
+++ b/pytorch_vision_densenet.md
@@ -7,7 +7,7 @@ summary: Dense Convolutional Network (DenseNet), connects each layer to every ot
 category: researchers
 image: densenet1.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/densenet.py
 featured_image_1: densenet1.png
 featured_image_2: densenet2.png

--- a/pytorch_vision_fcn_resnet101.md
+++ b/pytorch_vision_fcn_resnet101.md
@@ -7,7 +7,7 @@ summary: Fully-Convolutional Network model with a ResNet-101 backbone
 category: researchers
 image: fcn2.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/segmentation/fcn.py
 featured_image_1: deeplab1.png
 featured_image_2: fcn2.png

--- a/pytorch_vision_inception_v3.md
+++ b/pytorch_vision_inception_v3.md
@@ -7,7 +7,7 @@ summary: Also called GoogleNetv3, a famous ConvNet trained on Imagenet from 2015
 category: researchers
 image: inception_v3.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/inception.py
 featured_image_1: inception_v3.png
 featured_image_2: no-image

--- a/pytorch_vision_mobilenet_v2.md
+++ b/pytorch_vision_mobilenet_v2.md
@@ -7,7 +7,7 @@ summary: Efficient networks optimized for speed and memory, with residual blocks
 category: researchers
 image: mobilenet_v2_1.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/mobilenet.py
 featured_image_1: mobilenet_v2_1.png
 featured_image_2: mobilenet_v2_2.png

--- a/pytorch_vision_resnet.md
+++ b/pytorch_vision_resnet.md
@@ -7,7 +7,7 @@ summary: Deep residual networks pre-trained on ImageNet
 category: researchers
 image: resnet.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 featured_image_1: resnet.png
 featured_image_2: no-image

--- a/pytorch_vision_resnext.md
+++ b/pytorch_vision_resnext.md
@@ -7,7 +7,7 @@ summary: Next generation ResNets, more efficient and accurate
 category: researchers
 image: resnext.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 featured_image_1: resnext.png
 featured_image_2: no-image

--- a/pytorch_vision_shufflenet_v2.md
+++ b/pytorch_vision_shufflenet_v2.md
@@ -7,7 +7,7 @@ summary: An efficient ConvNet optimized for speed and memory, pre-trained on Ima
 category: researchers
 image: shufflenet_v2_1.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/shufflenetv2.py
 featured_image_1: shufflenet_v2_1.png
 featured_image_2: shufflenet_v2_2.png

--- a/pytorch_vision_squeezenet.md
+++ b/pytorch_vision_squeezenet.md
@@ -7,7 +7,7 @@ summary: Alexnet-level accuracy with 50x fewer parameters.
 category: researchers
 image: squeezenet.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/squeezenet.py
 featured_image_1: squeezenet.png
 featured_image_2: no-image

--- a/pytorch_vision_vgg.md
+++ b/pytorch_vision_vgg.md
@@ -7,7 +7,7 @@ summary: Award winning ConvNets from 2014 Imagenet ILSVRC challenge
 category: researchers
 image: vgg.png
 author: Pytorch Team
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/vgg.py
 featured_image_1: vgg.png
 featured_image_2: no-image

--- a/pytorch_vision_wide_resnet.md
+++ b/pytorch_vision_wide_resnet.md
@@ -7,7 +7,7 @@ summary: Wide Residual Networks
 category: researchers
 image: wide_resnet.png
 author: Sergey Zagoruyko
-tags: [vision]
+tags: [vision, scriptable]
 github-link: https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py
 featured_image_1: wide_resnet.png
 featured_image_2: no-image

--- a/scripts/tags.py
+++ b/scripts/tags.py
@@ -2,4 +2,5 @@ valid_tags = ['vision',
               'nlp',
               'generative',
               'audio',
+              'scriptable',
               ]


### PR DESCRIPTION
Adds a `scriptable` tag to all the models which compile under `torch.jit.script`. This is currently just the torchvision models. Potentially we could wait to wait till this till it shows inline python usage, however that might be blocked by https://github.com/pytorch/hub/pull/56

Bikeshedding around `scriptable` requested

