### PR TITLE
fix formatting for intelisl_midas_v2.md

### DIFF
--- a/intelisl_midas_v2.md
+++ b/intelisl_midas_v2.md
@@ -22,8 +22,8 @@ midas.eval()
 ```
 
 will load the MiDaS v2 model. The model expects 3-channel RGB images of shape ```(3 x H x W)```. Images are expected to be normalized using
-```mean=[0.485, 0.456, 0.406]``` and ```std=[0.229, 0.224, 0.225]```. 
-```H``` and ```W``` need to be divisible by ```32```. For optimal results ```H``` and ```W``` should be close to ```384``` (the training resolution). 
+`mean=[0.485, 0.456, 0.406]` and `std=[0.229, 0.224, 0.225]`. 
+`H` and `W` need to be divisible by `32`. For optimal results `H` and `W` should be close to `384` (the training resolution). 
 We provide a custom transformation that performs resizing while maintaining aspect ratio. 
 
 ### Model Description


### PR DESCRIPTION
The 2nd python cell in the [Jupyter notebook](https://github.com/pytorch/pytorch.github.io/blob/master/assets/hub/intelisl_midas_v2.ipynb) generated from intelisl_midas_v2.md wasn't formed correctly.

