### PR TITLE
Update pytorch_fairseq_translation.md

### DIFF
--- a/pytorch_fairseq_translation.md
+++ b/pytorch_fairseq_translation.md
@@ -10,6 +10,8 @@ author: Facebook AI (fairseq Team)
 tags: [nlp]
 github-link: https://github.com/pytorch/fairseq/
 github-id: pytorch/fairseq
+featured_image_1: no-image
+featured_image_2: no-image
 accelerator: cuda-optional
 order: 2
 ---


### PR DESCRIPTION
Updating the image path to: "featured_image_1: no-image" to avoid broken link icon on the page.