### PR TITLE
Add MoCo benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "benchmark/models/pytorch-CycleGAN-and-pix2pix"]
 	path = benchmark/models/pytorch-CycleGAN-and-pix2pix
 	url = https://github.com/zdevito/pytorch-CycleGAN-and-pix2pix
+[submodule "benchmark/models/moco"]
+	path = benchmark/models/moco
+	url = https://github.com/nickgg/moco.git


### PR DESCRIPTION
Adding benchmark based on facebookresearch/moco - gpu only.

The model only works in distributed gpu mode - I've constrained it to run on a single process, but there's still a little multiprocessing weirdness.