### PR TITLE
Utilities for comparing legacy/TE fuser

### DIFF
--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+from collections import namedtuple
+
+Result = namedtuple("Result", ["name", "base_time", "diff_time"])
+
+def get_times(pytest_data):
+    return {b["name"]: b["stats"]["mean"] for b in pytest_data["benchmarks"]}
+
+parser = argparse.ArgumentParser("compare two pytest jsons")
+parser.add_argument('base',  help="base json file")
+parser.add_argument('diff', help='diff json file')
+args = parser.parse_args()
+
+with open(args.base, "r") as base:
+    base_times = get_times(json.load(base))
+with open(args.diff, "r") as diff:
+    diff_times = get_times(json.load(diff))
+
+all_keys = set(base_times.keys()).union(diff_times.keys())
+results = [
+    Result(name, base_times.get(name, float("nan")), diff_times.get(name, float("nan")))
+    for name in sorted(all_keys)
+]
+
+print("{:48s} {:>13s} {:>15s} {:>10s}".format(
+    "name", "base time (s)", "diff time (s)", "% change"))
+for r in results:
+    print("{:48s} {:13.6f} {:15.6f} {:9.1f}%".format(
+        r.name,
+        r.base_time,
+        r.diff_time,
+        (r.diff_time / r.base_time - 1.0) * 100.0
+        ))

--- a/benchmark/compare.sh
+++ b/benchmark/compare.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pytest test_bench.py -k cuda-jit --fuser legacy --benchmark-json legacy.json
+pytest test_bench.py -k cuda-jit --fuser te --benchmark-json te.json
+python compare.py legacy.json te.json

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+import torch
+
+def pytest_addoption(parser):
+    parser.addoption("--fuser", help="fuser to use for benchmarks")
+
+def set_fuser(fuser):
+    if fuser == "legacy":
+        torch._C._jit_set_profiling_executor(False)
+        torch._C._jit_set_profiling_mode(False)
+        torch._C._jit_override_can_fuse_on_gpu(True)
+        torch._C._jit_set_texpr_fuser_enabled(False)
+    elif fuser == "te":
+        torch._C._jit_set_profiling_executor(True)
+        torch._C._jit_set_profiling_mode(True)
+        torch._C._jit_set_bailout_depth(20)
+        torch._C._jit_set_num_profiled_runs(2)
+        torch._C._jit_override_can_fuse_on_cpu(False)
+        torch._C._jit_override_can_fuse_on_gpu(False)
+        torch._C._jit_set_texpr_fuser_enabled(True)
+
+def pytest_configure(config):
+    set_fuser(config.getoption("fuser"))


### PR DESCRIPTION
First diff adds an optional `--fuser` command line option to the benchmark harness, that allows one to select the `legacy` or `te` fuser.  I made this a command-line option rather than a fixture because (a) outside the team developing the TE fuser I doubt the comparison data will be desirable, and (b) using different fusers/executors on the same graph in the same process is pretty unusual and might expose weird caching behavior that isn't worth getting to the bottom of.

Second diff just adds some scripts to munge `pytest-benchmark` json files and produce a nicely formatted table.  I can't get pytest-benchmark to produce suitably nice output; `--csv` doesn't really provide the "comparison" per se.  Doing it this way is "easy" since everything is very manual.