### PR TITLE
Circle-CI Build is failing due to huggingface/transformers

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,5 +15,5 @@ conda install -y regex pillow tqdm boto3 requests numpy\
 conda install -y -c conda-forge librosa inflect
 
 pip install -q fastBPE sacremoses sentencepiece subword_nmt editdistance
-pip install -q visdom mistune filelock tokenizers packaging
+pip install -q visdom mistune filelock tokenizers==0.8.1 packaging
 pip install -q omegaconf

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,6 @@ conda install -y regex pillow tqdm boto3 requests numpy\
 conda install -y -c conda-forge librosa inflect
 
 pip install -q fastBPE sacremoses sentencepiece subword_nmt editdistance
-pip install -q visdom mistune filelock tokenizers==0.8.1 packaging google
+pip install -q visdom mistune filelock tokenizers==0.9.0 packaging
 pip install -q omegaconf
 pip install -q hydra-core

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,6 @@ conda install -y regex pillow tqdm boto3 requests numpy\
 conda install -y -c conda-forge librosa inflect
 
 pip install -q fastBPE sacremoses sentencepiece subword_nmt editdistance
-pip install -q visdom mistune filelock tokenizers==0.8.1 packaging
+pip install -q visdom mistune filelock tokenizers==0.8.1 packaging google
 pip install -q omegaconf
 pip install -q hydra-core


### PR DESCRIPTION
When triggering the Circle-CI Build and running the `run_torch_hub` and, in this case, the `huggingface/transformers` examples, this error showed up first:

```
Running pytorch example in huggingface_pytorch-transformers.md
Downloading: "https://github.com/huggingface/pytorch-transformers/archive/master.zip" to /home/circleci/.cache/torch/hub/master.zip
Traceback (most recent call last):
  File "temp.py", line 2, in <module>
    tokenizer = torch.hub.load('huggingface/pytorch-transformers', 'tokenizer', 'bert-base-cased')
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torch/hub.py", line 349, in load
    hub_module = import_module(MODULE_HUBCONF, repo_dir + '/' + MODULE_HUBCONF)
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torch/hub.py", line 71, in import_module
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/hubconf.py", line 8, in <module>
    from transformers import (
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/__init__.py", line 68, in <module>
    from .data import (
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/data/__init__.py", line 6, in <module>
    from .processors import (
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/data/processors/__init__.py", line 6, in <module>
    from .squad import SquadExample, SquadFeatures, SquadV1Processor, SquadV2Processor, squad_convert_examples_to_features
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/data/processors/squad.py", line 10, in <module>
    from ...tokenization_bart import BartTokenizer
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_bart.py", line 18, in <module>
    from .tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_roberta.py", line 20, in <module>
    from .tokenization_gpt2 import GPT2Tokenizer, GPT2TokenizerFast
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_gpt2.py", line 27, in <module>
    from .tokenization_utils_fast import PreTrainedTokenizerFast
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_utils_fast.py", line 29, in <module>
    from .convert_slow_tokenizer import convert_slow_tokenizer
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/convert_slow_tokenizer.py", line 25, in <module>
    from tokenizers.models import BPE, Unigram, WordPiece
ImportError: cannot import name 'Unigram' from 'tokenizers.models' (/home/circleci/miniconda3/lib/python3.7/site-packages/tokenizers/models/__init__.py)
```

And later on (on the next automatic nighty build):

```
Running pytorch example in huggingface_pytorch-transformers.md
Downloading: "https://github.com/huggingface/pytorch-transformers/archive/master.zip" to /home/circleci/.cache/torch/hub/master.zip
Traceback (most recent call last):
  File "temp.py", line 2, in <module>
    tokenizer = torch.hub.load('huggingface/pytorch-transformers', 'tokenizer', 'bert-base-cased')
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torch/hub.py", line 349, in load
    hub_module = import_module(MODULE_HUBCONF, repo_dir + '/' + MODULE_HUBCONF)
  File "/home/circleci/miniconda3/lib/python3.7/site-packages/torch/hub.py", line 71, in import_module
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/hubconf.py", line 8, in <module>
    from transformers import (
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/__init__.py", line 68, in <module>
    from .data import (
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/data/__init__.py", line 6, in <module>
    from .processors import (
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/data/processors/__init__.py", line 6, in <module>
    from .squad import SquadExample, SquadFeatures, SquadV1Processor, SquadV2Processor, squad_convert_examples_to_features
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/data/processors/squad.py", line 10, in <module>
    from ...tokenization_bart import BartTokenizer
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_bart.py", line 18, in <module>
    from .tokenization_roberta import RobertaTokenizer, RobertaTokenizerFast
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_roberta.py", line 20, in <module>
    from .tokenization_gpt2 import GPT2Tokenizer, GPT2TokenizerFast
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_gpt2.py", line 27, in <module>
    from .tokenization_utils_fast import PreTrainedTokenizerFast
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/tokenization_utils_fast.py", line 29, in <module>
    from .convert_slow_tokenizer import convert_slow_tokenizer
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/convert_slow_tokenizer.py", line 28, in <module>
    from transformers.utils import sentencepiece_model_pb2 as model
  File "/home/circleci/.cache/torch/hub/huggingface_pytorch-transformers_master/src/transformers/utils/sentencepiece_model_pb2.py", line 9, in <module>
    from google.protobuf import descriptor as _descriptor
ModuleNotFoundError: No module named 'google'
```

More information about the build logs available at https://app.circleci.com/pipelines/github/pytorch/hub?branch=master. Related to the logs described above check: https://app.circleci.com/pipelines/github/pytorch/hub/755/workflows/87c91f7b-4cb1-417f-9913-21690fc73378/jobs/1181 and https://app.circleci.com/pipelines/github/pytorch/hub/756/workflows/28c5cd69-84e4-4b91-8dca-ff602bf135c0/jobs/1182, respectively.

Issue may be related to the huggingface/transformers release: https://github.com/huggingface/tokenizers/releases as the previous builds works as expected and nothing has changed since the last working build.

P.S.: This PR has been created so as to trigger the Circle-CI build but it may not work, so some more commits will be required.