### PR TITLE
PyTorch 1.7 compatibility

### DIFF
--- a/snakers4_silero-models_stt.md
+++ b/snakers4_silero-models_stt.md
@@ -27,7 +27,7 @@ import torchaudio
 from glob import glob
 
 device = torch.device('cpu')  # gpu also works, but our models are fast enough for CPU
-model, decoder, utils = torch.hub.load(github='snakers4/silero-models',
+model, decoder, utils = torch.hub.load(repo_or_dir='snakers4/silero-models',
                                        model='silero_stt',
                                        language='en', # also available 'de', 'es'
                                        device=device)


### PR DESCRIPTION
PyTorch 1.7 was just released, looks like this method's signature was changed
Also not `stft` shows some warnings, but I guess I will fix it in V2 (next major version) of silero models