### PR TITLE
Add demo model button to more models and removed unused front matter

### DIFF
--- a/facebookresearch_pytorch-gan-zoo_pgan.md
+++ b/facebookresearch_pytorch-gan-zoo_pgan.md
@@ -14,6 +14,7 @@ featured_image_1: pgan_mix.jpg
 featured_image_2: pgan_celebaHQ.jpg
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/19NTYFNUT9js78UZ0g_3IsnnUW9AsR0fD?usp=sharing
 ---
 
 

--- a/facebookresearch_pytorchvideo_x3d.md
+++ b/facebookresearch_pytorchvideo_x3d.md
@@ -4,26 +4,27 @@ background-class: hub-background
 body-class: hub
 category: researchers
 title: X3D
-summary: X3D networks pretrained on the Kinetics 400 dataset  
-image: x3d.png 
+summary: X3D networks pretrained on the Kinetics 400 dataset
+image: x3d.png
 author: FAIR PyTorchVideo
 tags: [vision]
 github-link: https://github.com/facebookresearch/pytorchvideo
 github-id: facebookresearch/pytorchvideo
-featured_image_1: no-image 
+featured_image_1: no-image
 featured_image_2: no-image
-accelerator: “cuda-optional” 
+accelerator: “cuda-optional”
+demo-model-link: https://colab.research.google.com/drive/1k6wG3gHFnFpC-hAMpL_s0B3Xj_ahsa19#scrollTo=-BkJOZgxK0pe
 ---
 
 ### Example Usage
 
 #### Imports
 
-Load the model: 
+Load the model:
 
 ```python
 import torch
-# Choose the `x3d_s` model 
+# Choose the `x3d_s` model
 model_name = 'x3d_s'
 model = torch.hub.load('facebookresearch/pytorchvideo', model_name, pretrained=True)
 ```
@@ -51,7 +52,7 @@ from pytorchvideo.transforms import (
 
 Set the model to eval mode and move to desired device.
 
-```python 
+```python
 # Set to GPU or CPU
 device = "cpu"
 model = model.eval()
@@ -177,13 +178,13 @@ print("Top 5 predicted labels: %s" % ", ".join(pred_class_names))
 ```
 
 ### Model Description
-X3D model architectures are based on [1] pretrained on the Kinetics dataset. 
+X3D model architectures are based on [1] pretrained on the Kinetics dataset.
 
 | arch | depth | frame length x sample rate | top 1 | top 5 | Flops (G) | Params (M) |
 | --------------- | ----------- | ----------- | ----------- | ----------- | ----------- |  ----------- | ----------- |
 | X3D      | XS    | 4x12                       | 69.12 | 88.63 | 0.91      | 3.79     |
 | X3D      | S     | 13x6                       | 73.33 | 91.27 | 2.96      | 3.79     |
-| X3D      | M     | 16x5                       | 75.94 | 92.72 | 6.72      | 3.79     | 
+| X3D      | M     | 16x5                       | 75.94 | 92.72 | 6.72      | 3.79     |
 
 
 ### References

--- a/intelisl_midas_v2.md
+++ b/intelisl_midas_v2.md
@@ -13,16 +13,15 @@ github-id: intel-isl/MiDaS
 featured_image_1: midas_samples.png
 featured_image_2: no-image
 accelerator: cuda-optional
-demo-model: true
-demo-model-link: https://colab.research.google.com/drive/1ky76hYQJvMvup6GAfsVhvExSWWJmxR4Q?usp=sharing#scrollTo=WFnsv2SONMs7
+demo-model-link: https://colab.research.google.com/drive/12uRtndAmIQVvI8JZk_qsAJvc3WGVnbYf?authuser=0#scrollTo=wacHQxxjOCCl
 ---
 
 ### Model Description
 
-[MiDaS](https://arxiv.org/abs/1907.01341) computes relative inverse depth from a single image. The repository provides multiple models that cover different use cases ranging from a small, high-speed model to a very large model that provide the highest accuracy. The models have been trained on 10 distinct datasets using 
-multi-objective optimization to ensure high quality on a wide range of inputs. 
+[MiDaS](https://arxiv.org/abs/1907.01341) computes relative inverse depth from a single image. The repository provides multiple models that cover different use cases ranging from a small, high-speed model to a very large model that provide the highest accuracy. The models have been trained on 10 distinct datasets using
+multi-objective optimization to ensure high quality on a wide range of inputs.
 
-### Dependencies 
+### Dependencies
 
 MiDaS depends on [timm](https://github.com/rwightman/pytorch-image-models). Install with
 ```shell

--- a/nicolalandro_ntsnet-cub200_ntsnet.md
+++ b/nicolalandro_ntsnet-cub200_ntsnet.md
@@ -13,6 +13,7 @@ github-id: nicolalandro/ntsnet-cub200
 featured_image_1: nts-net.png
 featured_image_2: no-image
 accelerator: "cuda-optional"
+demo-model-link: https://colab.research.google.com/drive/1hbZ4Fd23I0u_uVgIadeF2zqivIdCG5Zn?usp=sharing
 ---
 
 ```python

--- a/nvidia_deeplearningexamples_waveglow.md
+++ b/nvidia_deeplearningexamples_waveglow.md
@@ -14,8 +14,7 @@ featured_image_1: waveglow_diagram.png
 featured_image_2: no-image
 accelerator: cuda
 order: 3
-demo-model: true
-demo-model-link: https://colab.research.google.com/drive/1ykTxMsdstdPbDFgvjtBlbnG8Q0EVKm1w?usp=sharing#scrollTo=OBd3B1Bed7_d
+demo-model-link: https://colab.research.google.com/drive/1omouh8c4XIoZR1vw91X5AQUY2_nIKeNz?usp=sharing
 ---
 
 ```python

--- a/pytorch_fairseq_translation.md
+++ b/pytorch_fairseq_translation.md
@@ -14,6 +14,7 @@ featured_image_1: no-image
 featured_image_2: no-image
 accelerator: cuda-optional
 order: 2
+demo-model-link: https://colab.research.google.com/drive/1C5fmU5vecWy3oTf5NsJUlwfI6m9i8-x0?usp=sharing
 ---
 
 

--- a/snakers4_silero-models_stt.md
+++ b/snakers4_silero-models_stt.md
@@ -13,7 +13,6 @@ github-id: snakers4/silero-models
 featured_image_1: silero_stt_model.jpg
 featured_image_2: silero_imagenet_moment.png
 accelerator: cuda-optional
-demo-model: true
 demo-model-link: https://colab.research.google.com/drive/1EmSGE0eQbflVhFiFaOVssQkxGSwVou3L?authuser=1#scrollTo=mJ8PvvrxKDAC
 ---
 

--- a/snakers4_silero-vad_language.md
+++ b/snakers4_silero-vad_language.md
@@ -13,6 +13,7 @@ github-id: snakers4/silero-vad
 featured_image_1: no-image
 featured_image_2: no-image
 accelerator: cuda-optional
+demo-model-link: https://colab.research.google.com/drive/1QSiUv_3hZzC_7EEN4rY_VDUvD4F-8ofQ#scrollTo=3kWsxeMn_q1c
 ---
 
 

--- a/ultralytics_yolov5.md
+++ b/ultralytics_yolov5.md
@@ -13,8 +13,7 @@ github-id: ultralytics/yolov5
 featured_image_1: ultralytics_yolov5_img1.jpg
 featured_image_2: ultralytics_yolov5_img2.png
 accelerator: cuda-optional
-demo-model: true
-demo-model-link: https://colab.research.google.com/drive/1gTvmKK2008QnIqgFr0jn49p4x7fNrvfS?usp=sharing
+demo-model-link: https://colab.research.google.com/drive/1AiuBDleOUM5Vyq3Itq3edCjg5J8I719p?usp=sharing
 ---
 
 ## Before You Start
@@ -42,11 +41,11 @@ pip install -qr https://raw.githubusercontent.com/ultralytics/yolov5/master/requ
 
 <details>
   <summary>Table Notes (click to expand)</summary>
-  
-  * AP<sup>test</sup> denotes COCO [test-dev2017](http://cocodataset.org/#upload) server results, all other AP results denote val2017 accuracy.  
-  * AP values are for single-model single-scale unless otherwise noted. **Reproduce mAP** by `python test.py --data coco.yaml --img 640 --conf 0.001 --iou 0.65`  
-  * Speed<sub>GPU</sub> averaged over 5000 COCO val2017 images using a GCP [n1-standard-16](https://cloud.google.com/compute/docs/machine-types#n1_standard_machine_types) V100 instance, and includes FP16 inference, postprocessing and NMS. **Reproduce speed** by `python test.py --data coco.yaml --img 640 --conf 0.25 --iou 0.45`  
-  * All checkpoints are trained to 300 epochs with default settings and hyperparameters (no autoaugmentation). 
+
+  * AP<sup>test</sup> denotes COCO [test-dev2017](http://cocodataset.org/#upload) server results, all other AP results denote val2017 accuracy.
+  * AP values are for single-model single-scale unless otherwise noted. **Reproduce mAP** by `python test.py --data coco.yaml --img 640 --conf 0.001 --iou 0.65`
+  * Speed<sub>GPU</sub> averaged over 5000 COCO val2017 images using a GCP [n1-standard-16](https://cloud.google.com/compute/docs/machine-types#n1_standard_machine_types) V100 instance, and includes FP16 inference, postprocessing and NMS. **Reproduce speed** by `python test.py --data coco.yaml --img 640 --conf 0.25 --iou 0.45`
+  * All checkpoints are trained to 300 epochs with default settings and hyperparameters (no autoaugmentation).
   * Test Time Augmentation ([TTA](https://github.com/ultralytics/yolov5/issues/303)) includes reflection and scale augmentation. **Reproduce TTA** by `python test.py --data coco.yaml --img 1536 --iou 0.7 --augment`
 
 </details>
@@ -55,8 +54,8 @@ pip install -qr https://raw.githubusercontent.com/ultralytics/yolov5/master/requ
 
 <details>
   <summary>Figure Notes (click to expand)</summary>
-  
-  * GPU Speed measures end-to-end time per image averaged over 5000 COCO val2017 images using a V100 GPU with batch size 32, and includes image preprocessing, PyTorch FP16 inference, postprocessing and NMS. 
+
+  * GPU Speed measures end-to-end time per image averaged over 5000 COCO val2017 images using a V100 GPU with batch size 32, and includes image preprocessing, PyTorch FP16 inference, postprocessing and NMS.
   * EfficientDet data from [google/automl](https://github.com/google/automl) at batch size 8.
   * **Reproduce** by `python test.py --task study --data coco.yaml --iou 0.7 --weights yolov5s6.pt yolov5m6.pt yolov5l6.pt yolov5x6.pt`
 
@@ -102,7 +101,7 @@ results.pandas().xyxy[0]  # img1 predictions (pandas)
 ## Contact
 
 
-**Issues should be raised directly in https://github.com/ultralytics/yolov5.** For business inquiries or professional support requests please visit [https://ultralytics.com](https://ultralytics.com) or email Glenn Jocher at [glenn.jocher@ultralytics.com](mailto:glenn.jocher@ultralytics.com). 
+**Issues should be raised directly in https://github.com/ultralytics/yolov5.** For business inquiries or professional support requests please visit [https://ultralytics.com](https://ultralytics.com) or email Glenn Jocher at [glenn.jocher@ultralytics.com](mailto:glenn.jocher@ultralytics.com).
 
 
 &nbsp;


### PR DESCRIPTION
This PR: 

- Adds demo model button to PGAN, X3D, MiDaS, ntsnet, WaveGlow, NMT, Silero Speech-To-Text Models, Silero Language Classifier, YOLOv5 models.
- Removes unused `demo-model` front-matter from YOLOv5, Silero Speech-To-Text Models, WaveGlow, MiDaS models.