### PR TITLE
Fix pip install issue with roberta torch hub demo

### DIFF
--- a/pytorch_fairseq_roberta.md
+++ b/pytorch_fairseq_roberta.md
@@ -37,7 +37,7 @@ better to downstream tasks compared to BERT.
 We require a few additional Python dependencies for preprocessing:
 
 ```bash
-pip install regex requests
+pip install regex requests hydra-core omegaconf
 ```
 
 


### PR DESCRIPTION
In the current state, when running the Colab demo linked in torch hub for roberta, an error will be thrown since hydra-core and omegaconf are not installed by default in colab. This PR should fix the issue.