### PR TITLE
Skip huggingface tests due to rate limiting.

### DIFF
--- a/scripts/run_pytorch.sh
+++ b/scripts/run_pytorch.sh
@@ -18,6 +18,9 @@ do
   # FIXME: torch.nn.modules.module.ModuleAttributeError: 'autoShape' object has no attribute 'fuse'
   elif [[ $f = "ultralytics_yolov5"* ]]; then
     echo "...temporarily disabled"
+  elif [[ $f = "huggingface_pytorch-transformers"* ]]; then
+    echo "...temporarily disabled"
+  # FIXME: rate limiting
   else
     sed -n '/^```python/,/^```/ p' < $f | sed '/^```/ d' > $TEMP_PY
     python $TEMP_PY


### PR DESCRIPTION
There seems to be IP based rate limiting there (as it failed on circleCi and Google colab but not on my devfair). So skipping for now, need followup to investigate why rate limiting happens. 