### PR TITLE
Add demo model button to models

### DIFF
--- a/nvidia_deeplearningexamples_ssd.md
+++ b/nvidia_deeplearningexamples_ssd.md
@@ -14,6 +14,7 @@ featured_image_1: ssd_diagram.png
 featured_image_2: ssd.png
 accelerator: cuda
 order: 10
+demo-model-link: https://colab.research.google.com/drive/19G612KDFbZArK4dKFDd8CskaJpQrdfPp#scrollTo=54szZ5JAiinp
 ---
 
 

--- a/nvidia_deeplearningexamples_tacotron2.md
+++ b/nvidia_deeplearningexamples_tacotron2.md
@@ -14,6 +14,7 @@ featured_image_1: tacotron2_diagram.png
 featured_image_2: no-image
 accelerator: cuda
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1OgWtMVvjMvV0_ujexBhgqQfZpnnfBOMy#scrollTo=dinuhyj_5zNC
 ---
 
 

--- a/pytorch_vision_alexnet.md
+++ b/pytorch_vision_alexnet.md
@@ -14,6 +14,7 @@ featured_image_1: alexnet1.png
 featured_image_2: alexnet2.png
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1avee9yGqxf2cSE3AaYctXPilfibhXo3M
 ---
 
 ```python

--- a/pytorch_vision_densenet.md
+++ b/pytorch_vision_densenet.md
@@ -14,6 +14,7 @@ featured_image_1: densenet1.png
 featured_image_2: densenet2.png
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1zZGSyJUchpeIfMDgyzFTLRQF-uyX9sQN
 ---
 
 ```python

--- a/pytorch_vision_inception_v3.md
+++ b/pytorch_vision_inception_v3.md
@@ -14,6 +14,7 @@ featured_image_1: inception_v3.png
 featured_image_2: no-image
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1KPpTEcUa6KECkNfq1pYbBK8xBaMt1Eek
 ---
 
 ```python

--- a/pytorch_vision_mobilenet_v2.md
+++ b/pytorch_vision_mobilenet_v2.md
@@ -14,6 +14,7 @@ featured_image_1: mobilenet_v2_1.png
 featured_image_2: mobilenet_v2_2.png
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1zjsamXNjQBsbvuR0y5-dDZgTO8XXun4A
 ---
 
 ```python

--- a/pytorch_vision_shufflenet_v2.md
+++ b/pytorch_vision_shufflenet_v2.md
@@ -14,6 +14,7 @@ featured_image_1: shufflenet_v2_1.png
 featured_image_2: shufflenet_v2_2.png
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1p8lWqa2q0xxMccFGgGExoZpvnAeTFDNb
 ---
 
 ```python

--- a/pytorch_vision_squeezenet.md
+++ b/pytorch_vision_squeezenet.md
@@ -14,6 +14,7 @@ featured_image_1: squeezenet.png
 featured_image_2: no-image
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1ew6BWenc9omDBTliy0TJsiKvvb9BQXNR
 ---
 
 ```python

--- a/pytorch_vision_vgg.md
+++ b/pytorch_vision_vgg.md
@@ -14,6 +14,7 @@ featured_image_1: vgg.png
 featured_image_2: no-image
 accelerator: cuda-optional
 order: 10
+demo-model-link: https://colab.research.google.com/drive/1j1mEt6VzgmLfSPrKZfwUTk9cH9KTYFJ9
 ---
 
 ```python

--- a/snakers4_silero-vad_vad.md
+++ b/snakers4_silero-vad_vad.md
@@ -13,6 +13,7 @@ github-id: snakers4/silero-vad
 featured_image_1: silero_vad_performance.png
 featured_image_2: no-image
 accelerator: cuda-optional
+demo-model-link: https://colab.research.google.com/drive/11bhiuFdZ8B2imtEtlHzeU7t-_B59rJxn#scrollTo=udksZuZw0G0i
 ---
 
 


### PR DESCRIPTION
This PR adds Demo Model button to these models: 

1. SSD
2. Tacotron 2
3. AlexNet
4. Densenet
5. Inception_v3
6. MobileNet v2
7. ShuffleNet v2
8. SqueezeNet
9. vgg-nets
10. Silero Voice Activity Detector

Preview: https://60de12b0d9e3f312fd70fbf2--shiftlab-pytorch-github-io.netlify.app/hub/research-models