### PR TITLE
skip fairseq roberta due to run-time error

### DIFF
--- a/scripts/run_pytorch.sh
+++ b/scripts/run_pytorch.sh
@@ -20,6 +20,9 @@ do
     echo "...temporarily disabled"
   elif [[ $f = "huggingface_pytorch-transformers"* ]]; then
     echo "...temporarily disabled"
+  # FIXME: TypeError: compose() got an unexpected keyword argument 'strict'
+  elif [[ $f = "pytorch_fairseq_roberta"* ]]; then
+    echo "...temporarily disabled"
   # FIXME: rate limiting
   else
     sed -n '/^```python/,/^```/ p' < $f | sed '/^```/ d' > $TEMP_PY


### PR DESCRIPTION
Skipping fairseq roberta in CI testing as the model is currently giving following error:
`TypeError: compose() got an unexpected keyword argument 'strict'`

An issue is also raised by the user on fairseq repo: https://github.com/pytorch/fairseq/issues/3723