### PR TITLE
Use pytorch nightly in CI

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,8 +4,8 @@ set -e
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-# Install the latest release of pytorch and torchvision
-conda install -y pytorch torchvision -c pytorch
+conda install -y pytorch -c pytorch-nightly
+conda install -y torchvision -c pytorch
 # Also install torchaudio
 conda install -y -c pytorch torchaudio
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,9 +4,7 @@ set -e
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-conda install -y pytorch torchvision -c pytorch-nightly
-# Also install torchaudio
-conda install -y -c pytorch-nightly torchaudio
+conda install -y pytorch torchvision torchaudio -c pytorch-nightly
 
 # Dependencies required to load models
 conda install -y regex pillow tqdm boto3 requests numpy\

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,10 +4,9 @@ set -e
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-conda install -y pytorch -c pytorch-nightly
-conda install -y torchvision -c pytorch
+conda install -y pytorch torchvision -c pytorch-nightly
 # Also install torchaudio
-conda install -y -c pytorch torchaudio
+conda install -y -c pytorch-nightly torchaudio
 
 # Dependencies required to load models
 conda install -y regex pillow tqdm boto3 requests numpy\


### PR DESCRIPTION
This PR changes the pytorch dep to be pytorch nightly instead of pytorch.

Without pytorch nightly, we have no way of figuring out whether fixes like https://github.com/pytorch/pytorch/pull/62072 are actually working.

We also have no way of knowing in advance whether some change in pytorch will break torchhub or not, which leads to the current disaster of torchhub being down for the entire 1.9 release https://github.com/pytorch/pytorch/issues/61755