### PR TITLE
Fix typo in deeplabv3_resnet101.md

### DIFF
--- a/pytorch_vision_deeplabv3_resnet101.md
+++ b/pytorch_vision_deeplabv3_resnet101.md
@@ -31,7 +31,7 @@ The images have to be loaded in to a range of `[0, 1]` and then normalized using
 and `std = [0.229, 0.224, 0.225]`.
 
 The model returns an `OrderedDict` with two Tensors that are of the same height and width as the input Tensor, but with 21 classes.
-`output['out']` contains the semantic masks, and `output['aux']` contains the auxillary loss values per-pixel. In inference mode, `output['aux']` is not useful.
+`output['out']` contains the semantic masks, and `output['aux']` contains the auxiliary loss values per-pixel. In inference mode, `output['aux']` is not useful.
 So, `output['out']` is of shape `(N, 21, H, W)`. More documentation can be found [here](https://pytorch.org/docs/stable/torchvision/models.html#object-detection-instance-segmentation-and-person-keypoint-detection).
 
 


### PR DESCRIPTION
@NicolasHug  

Just simple typo error,  

In deeplabv3 they use auxiliary loss.  
The sentence below should be changed to:  

`output['aux']` contains the auxillary loss values per-pixel.  
👇👇👇
`output['aux']` contains the auxiliary loss values per-pixel.  