### PR TITLE
Improvements in NVIDIA convnets access and display

### DIFF
--- a/nvidia_deeplearningexamples_efficientnet.md
+++ b/nvidia_deeplearningexamples_efficientnet.md
@@ -35,7 +35,7 @@ In the example below we will use the pretrained ***EfficientNet*** model to perf
 
 To run the example you need some extra python packages installed. These are needed for preprocessing images and visualization.
 ```python
-!pip install validators
+!pip install validators matplotlib
 ```
 
 ```python
@@ -45,6 +45,10 @@ import torchvision.transforms as transforms
 import numpy as np
 import json
 import requests
+import matplotlib.pyplot as plt
+import warnings
+warnings.filterwarnings('ignore')
+%matplotlib inline
 
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 print(f'Using {device} for inference')
@@ -52,18 +56,18 @@ print(f'Using {device} for inference')
 
 Load the model pretrained on IMAGENET dataset.
 
-By setting *type* parameter you can choose among the following models:
+You can choose among the following models:
 
-| Type | Description |
+| TorchHub entrypoint | Description |
 | :----- | :----- |
-| `efficientnet-b0` | baseline EfficientNet |
-| `efficientnet-b4` | scaled EfficientNet|
-| `efficientnet-widese-b0` | model with Squeeze-and-Excitation layers wider than baseline EfficientNet model |
-| `efficientnet-widese-b4` | model with Squeeze-and-Excitation layers wider than scaled EfficientNet model |
+| `nvidia_efficientnet_b0` | baseline EfficientNet |
+| `nvidia_efficientnet_b4` | scaled EfficientNet|
+| `nvidia_efficientnet_widese_b0` | model with Squeeze-and-Excitation layers wider than baseline EfficientNet model |
+| `nvidia_efficientnet_widese_b4` | model with Squeeze-and-Excitation layers wider than scaled EfficientNet model |
 
 There are also quantized version of the models, but they require nvidia container. See [quantized models](https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/Classification/ConvNets/efficientnet#quantization)
 ```python
-efficientnet = torch.hub.load('NVIDIA/DeepLearningExamples:torchhub', 'nvidia_efficientnet', type='efficientnet-widese-b0')
+efficientnet = torch.hub.load('NVIDIA/DeepLearningExamples:torchhub', 'nvidia_efficientnet_b0', pretrained=True)
 utils = torch.hub.load('NVIDIA/DeepLearningExamples:torchhub', 'nvidia_convnets_processing_utils')
 
 efficientnet.eval().to(device)
@@ -97,7 +101,8 @@ Display the result.
 for uri, result in zip(uris, results):
     img = Image.open(requests.get(uri, stream=True).raw)
     img.thumbnail((256,256), Image.ANTIALIAS)
-    img.show()
+    plt.imshow(img)
+    plt.show()
     print(result)
 ```
 

--- a/nvidia_deeplearningexamples_resnet50.md
+++ b/nvidia_deeplearningexamples_resnet50.md
@@ -39,7 +39,7 @@ In the example below we will use the pretrained ***ResNet50 v1.5*** model to per
 
 To run the example you need some extra python packages installed. These are needed for preprocessing images and visualization.
 ```python
-!pip install validators
+!pip install validators matplotlib
 ```
 
 ```python
@@ -49,6 +49,10 @@ import torchvision.transforms as transforms
 import numpy as np
 import json
 import requests
+import matplotlib.pyplot as plt
+import warnings
+warnings.filterwarnings('ignore')
+%matplotlib inline
 
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 print(f'Using {device} for inference')
@@ -56,7 +60,7 @@ print(f'Using {device} for inference')
 
 Load the model pretrained on IMAGENET dataset.
 ```python
-resnet50 = torch.hub.load('NVIDIA/DeepLearningExamples:torchhub', 'nvidia_resnet50')
+resnet50 = torch.hub.load('NVIDIA/DeepLearningExamples:torchhub', 'nvidia_resnet50', pretrained=True)
 utils = torch.hub.load('NVIDIA/DeepLearningExamples:torchhub', 'nvidia_convnets_processing_utils')
 
 resnet50.eval().to(device)
@@ -89,7 +93,8 @@ Display the result.
 for uri, result in zip(uris, results):
     img = Image.open(requests.get(uri, stream=True).raw)
     img.thumbnail((256,256), Image.ANTIALIAS)
-    img.show()
+    plt.imshow(img)
+    plt.show()
     print(result)
 
 ```
@@ -106,4 +111,4 @@ and/or [NGC](https://ngc.nvidia.com/catalog/resources/nvidia:resnet_50_v1_5_for_
  - [model on github](https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/Classification/ConvNets/resnet50v1.5)
  - [model on NGC](https://ngc.nvidia.com/catalog/resources/nvidia:resnet_50_v1_5_for_pytorch)
  - [pretrained model on NGC](https://ngc.nvidia.com/catalog/models/nvidia:resnet50_pyt_amp)
-
+ 

--- a/nvidia_deeplearningexamples_resnext.md
+++ b/nvidia_deeplearningexamples_resnext.md
@@ -31,7 +31,7 @@ Note that the ResNeXt101-32x4d model can be deployed for inference on the [NVIDI
 
 #### Model architecture
 
-![ResNextArch](ResNeXtArch.png)
+![ResNextArch](https://pytorch.org/assets/images/ResNeXtArch.png)
 
 _Image source: [Aggregated Residual Transformations for Deep Neural Networks](https://arxiv.org/pdf/1611.05431.pdf)_
 
@@ -44,7 +44,7 @@ In the example below we will use the pretrained ***ResNeXt101-32x4d*** model to 
 
 To run the example you need some extra python packages installed. These are needed for preprocessing images and visualization.
 ```python
-!pip install validators
+!pip install validators matplotlib
 ```
 
 ```python
@@ -54,6 +54,10 @@ import torchvision.transforms as transforms
 import numpy as np
 import json
 import requests
+import matplotlib.pyplot as plt
+import warnings
+warnings.filterwarnings('ignore')
+%matplotlib inline
 
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 print(f'Using {device} for inference')
@@ -95,7 +99,8 @@ Display the result.
 for uri, result in zip(uris, results):
     img = Image.open(requests.get(uri, stream=True).raw)
     img.thumbnail((256,256), Image.ANTIALIAS)
-    img.show()
+    plt.imshow(img)
+    plt.show()
     print(result)
 
 ```
@@ -112,4 +117,3 @@ and/or [NGC](https://ngc.nvidia.com/catalog/resources/nvidia:resnext_for_pytorch
  - [model on github](https://github.com/NVIDIA/DeepLearningExamples/tree/master/PyTorch/Classification/ConvNets/resnext101-32x4d)
  - [model on NGC](https://ngc.nvidia.com/catalog/resources/nvidia:resnext_for_pytorch)
  - [pretrained model on NGC](https://ngc.nvidia.com/catalog/models/nvidia:resnext101_32x4d_pyt_amp)
-


### PR DESCRIPTION
@vmoens @soumith PIL img.show() failed to display images in gcollab, so we changed to matplotlib. We also cleaned entrypoints in our hubconf.py and adapted the notebooks correspondingly.