### PR TITLE
Fix sanity check due to new mistune version

### DIFF
--- a/scripts/sanity_check.py
+++ b/scripts/sanity_check.py
@@ -97,15 +97,16 @@ class ValidMD:
                              .format(field, value, self.filename))
 
     def validate_markdown(self, markdown):
-        m = mistune.Markdown()
-        blocks = m.block(mistune.preprocessing(markdown))
+        m = mistune.create_markdown(renderer=mistune.AstRenderer())
 
-        for block in blocks:
+        for block in m(markdown):
             if block['type'] == 'heading':
                 # we dont want colon after section names
-                assert not block['text'].endswith(':')
-                if block['text'] in self.required_sections:
-                    self.required_sections.remove(block['text'])
+                text_children = [c for c in block['children'] if c['type'] == 'text']
+                for c in text_children:
+                    assert not c['text'].endswith(':')
+                    if c['text'] in self.required_sections:
+                        self.required_sections.remove(c['text'])
         try:
             assert len(self.required_sections) == 0
         except AssertionError as e:


### PR DESCRIPTION
Mistune 2.0 is out with some breaking changes, it doesn't parse the markdown files the same way it used to, leading to failures like in https://app.circleci.com/pipelines/github/pytorch/hub/1491/workflows/32ba622d-23bd-49e3-8a9c-9e3a5aa5532a/jobs/1926


This PR fixes our script to rely on mistune's latest version.