### PR TITLE
Fix typo in 3D ResNet

### DIFF
--- a/facebookresearch_pytorchvideo_resnet.md
+++ b/facebookresearch_pytorchvideo_resnet.md
@@ -160,6 +160,7 @@ print("Top 5 predicted labels: %s" % ", ".join(pred_class_names))
 ### Model Description
 The model architecture is based on [1] with pretrained weights using the 8x8 setting
 on the Kinetics dataset. 
+
 | arch | depth | frame length x sample rate | top 1 | top 5 | Flops (G) | Params (M) |
 | --------------- | ----------- | ----------- | ----------- | ----------- | ----------- |  ----------- |
 | Slow     | R50   | 8x8                        | 74.58 | 91.63 | 54.52     | 32.45     |

--- a/facebookresearch_pytorchvideo_resnet.md
+++ b/facebookresearch_pytorchvideo_resnet.md
@@ -161,7 +161,7 @@ print("Top 5 predicted labels: %s" % ", ".join(pred_class_names))
 The model architecture is based on [1] with pretrained weights using the 8x8 setting
 on the Kinetics dataset. 
 | arch | depth | frame length x sample rate | top 1 | top 5 | Flops (G) | Params (M) |
-| --------------- | ----------- | ----------- | ----------- | ----------- | ----------- |  ----------- | ----------- |
+| --------------- | ----------- | ----------- | ----------- | ----------- | ----------- |  ----------- |
 | Slow     | R50   | 8x8                        | 74.58 | 91.63 | 54.52     | 32.45     |
 
 


### PR DESCRIPTION
@NicolasHug 

I just found a simple typo error.
In 3D ResNet (facebookresearch_pytorchvideo_resnet.md), table is broken.

| arch | depth | frame length x sample rate | top 1 | top 5 | Flops (G) | Params (M) |
| --------------- | ----------- | ----------- | ----------- | ----------- | ----------- |  ----------- | ----------- |
| Slow     | R50   | 8x8                        | 74.58 | 91.63 | 54.52     | 32.45     |

👇
| arch | depth | frame length x sample rate | top 1 | top 5 | Flops (G) | Params (M) |
| --------------- | ----------- | ----------- | ----------- | ----------- | ----------- |  ----------- |
| Slow     | R50   | 8x8                        | 74.58 | 91.63 | 54.52     | 32.45     |