### PR TITLE
Fix: lost reference number

### DIFF
--- a/facebookresearch_pytorch-gan-zoo_pgan.md
+++ b/facebookresearch_pytorch-gan-zoo_pgan.md
@@ -67,4 +67,4 @@ Progressive Growing of GANs is a method developed by Karras et. al. [1] in 2017 
 
 ### References
 
-- [Progressive Growing of GANs for Improved Quality, Stability, and Variation](https://arxiv.org/abs/1710.10196)
+[1] Tero Karras et al, "Progressive Growing of GANs for Improved Quality, Stability, and Variation" https://arxiv.org/abs/1710.10196


### PR DESCRIPTION
@NicolasHug 

I found a strange sentence

in line 62, There is a reference to [1]
> Progressive Growing of GANs is a method developed by Karras et. al. [1] in 2017 allowing generation of high resolution images. To do so, the generative network is trained slice by slice. At first the model is trained to build very low resolution images, once it converges, new layers are added and the output resolution doubles. The process continues until the desired resolution is reached.

But I don't see [1] in the docs.

So, I modified it by referring to other documents written on facebookresearch [facebookresearch_pytorchvideo_x3d](https://github.com/pytorch/hub/blob/master/facebookresearch_pytorchvideo_x3d.md)