### PR TITLE
Fix typo in ResNeXt101

### DIFF
--- a/nvidia_deeplearningexamples_resnext.md
+++ b/nvidia_deeplearningexamples_resnext.md
@@ -87,7 +87,7 @@ batch = torch.cat(
 ).to(device)
 ```
 
-Run inference. Use `pick_n_best(predictions=output, n=topN)` helepr function to pick N most probably hypothesis according to the model.
+Run inference. Use `pick_n_best(predictions=output, n=topN)` helper function to pick N most probably hypothesis according to the model.
 ```python
 with torch.no_grad():
     output = torch.nn.functional.softmax(resneXt(batch), dim=1)


### PR DESCRIPTION
I found a simple typo error in `ResNeXt101`.


helepr -> helper