### PR TITLE
Use torch-nightly build with CUDA-11.8

### DIFF
--- a/scripts/install_conda.sh
+++ b/scripts/install_conda.sh
@@ -10,3 +10,4 @@ bash "$filename" -b -u
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 conda install -y python=3.8
+conda update -y conda

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -4,7 +4,7 @@ set -ex
 . ~/miniconda3/etc/profile.d/conda.sh
 conda activate base
 
-conda install -y pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch-nightly -c nvidia
+conda install -y pytorch torchvision torchaudio pytorch-cuda=11.8 -c pytorch-nightly -c nvidia
 conda install -y pytest
 
 # Dependencies required to load models


### PR DESCRIPTION
There are no CUDA-11.6 pytorch nightlies for the last 90 days or so
Also, something I don't understand, but run `conda update -y conda` to be able to install anything. 