### PR TITLE
[Minor] Fix typos

### DIFF
--- a/pytorch_vision_vgg.md
+++ b/pytorch_vision_vgg.md
@@ -92,12 +92,12 @@ for i in range(top5_prob.size(0)):
 ### Model Description
 
 Here we have implementations for the models proposed in [Very Deep Convolutional Networks for Large-Scale Image Recognition](https://arxiv.org/abs/1409.1556),
-for each configurations and their with bachnorm version.
+for each configurations and their with batchnorm version.
 
 For example, configuration `A` presented in the paper is `vgg11`, configuration `B` is `vgg13`, configuration `D` is `vgg16`
 and configuration `E` is `vgg19`. Their batchnorm version are suffixed with `_bn`.
 
-Their 1-crop error rates on imagenet dataset with pretrained models are listed below.
+Their Top-1 error rates on ImageNet dataset with pretrained models are listed below.
 
 | Model structure | Top-1 error | Top-5 error |
 | --------------- | ----------- | ----------- |

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -12,7 +12,8 @@ conda install -y regex pillow tqdm boto3 requests numpy h5py scipy matplotlib un
 conda install -y -c conda-forge librosa inflect
 
 pip install -q fastBPE sacremoses sentencepiece subword_nmt editdistance
-pip install -q visdom mistune filelock tokenizers packaging pandas
+pip install -q visdom filelock tokenizers packaging pandas
+pip install -q mistune==2.0.2
 pip install -q omegaconf timm seaborn importlib_metadata huggingface_hub
 pip install -q hydra-core opencv-python fvcore
 pip install -q --upgrade google-api-python-client

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -12,8 +12,7 @@ conda install -y regex pillow tqdm boto3 requests numpy h5py scipy matplotlib un
 conda install -y -c conda-forge librosa inflect
 
 pip install -q fastBPE sacremoses sentencepiece subword_nmt editdistance
-pip install -q visdom filelock tokenizers packaging pandas
-pip install -q mistune==2.0.2
+pip install -q visdom mistune filelock tokenizers packaging pandas
 pip install -q omegaconf timm seaborn importlib_metadata huggingface_hub
 pip install -q hydra-core opencv-python fvcore
 pip install -q --upgrade google-api-python-client


### PR DESCRIPTION
`bachnorm`-> `batchnorm`

`imagenet` -> `ImageNet`

Because ImageNet is a proper noun, it retains the ImageNet word